### PR TITLE
RosBackend: ignore backend_name in eval_exog_function

### DIFF
--- a/src/ros_backend.cpp
+++ b/src/ros_backend.cpp
@@ -95,34 +95,27 @@ gpp::Value RosBackend::eval_exog_function(
 	const string &backend_name,
 	const std::unordered_map<string, Value> &args
 ) {
-	if (backend_name == "sense_result" || backend_name == "sense_number") {
-		string act_name = static_cast<string>(args.at("ros_action_name"));
-		AbstractActionManager &act_mgr = *action_managers_.at(act_name);
+	string act_name = static_cast<string>(args.at("ros_action_name"));
+	AbstractActionManager &act_mgr = *action_managers_.at(act_name);
 
-		if (!act_mgr.current_activity()->target()->senses())
-			throw gologpp::UserError(
-				backend_name + ": " + act_mgr.current_activity()->target()->str()
-				+ " is not a sensing action"
-			);
-
-		auto opt_result = act_mgr.result();
-
-		if (!opt_result)
-			throw gologpp::UserError(
-				backend_name + ": " + act_mgr.current_activity()->str()
-				+ " has not provided a sensing result"
-			);
-
-		if (opt_result.value().type() <= return_type)
-			return opt_result.value();
-		else
-			throw gologpp::TypeError(opt_result.value(), return_type);
-	}
-	else
+	if (!act_mgr.current_activity()->target()->senses())
 		throw gologpp::UserError(
-			"No exog_function '" + backend_name + "'. "
-			"Only 'sense_result(ros_action_name) or sense_number(ros_action_name)' is currently supported"
+			backend_name + ": " + act_mgr.current_activity()->target()->str()
+			+ " is not a sensing action"
 		);
+
+	auto opt_result = act_mgr.result();
+
+	if (!opt_result)
+		throw gologpp::UserError(
+			backend_name + ": " + act_mgr.current_activity()->str()
+			+ " has not provided a sensing result"
+		);
+
+	if (opt_result.value().type() <= return_type)
+		return opt_result.value();
+	else
+		throw gologpp::TypeError(opt_result.value(), return_type);
 }
 
 void RosBackend::terminate_()


### PR DESCRIPTION
We don't really care about the name of the exog_function. In fact, checking the name is an unnecessary restriction that requires us to modify the RosBackend each time we want to sense a new type.